### PR TITLE
Add block retrieval to spot check

### DIFF
--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -96,7 +96,7 @@ export default class SpotChecker {
    * @param {string} args.cid
    * @param {object} args.stats
    * @param {'all' | 'block'} args.dagScope
-   * @param {number} [args.maxByteLength]
+   * @param {number} [args.maxByteLength] Maximum bytes to download before stopping retrieval (optional)
    * */
   async fetchCAR ({ protocol, address, cid, stats, dagScope, maxByteLength }) {
     // Abort if no progress was made for 60 seconds

--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -75,8 +75,8 @@ export default class SpotChecker {
       protocol: provider.protocol,
       address: provider.address,
       cid: task.cid,
-      stats,
       dagScope: 'block',
+      stats,
       maxByteLength
     })
 
@@ -84,8 +84,8 @@ export default class SpotChecker {
       protocol: provider.protocol,
       address: provider.address,
       cid: task.cid,
-      stats,
       dagScope: 'all',
+      stats,
       maxByteLength
     })
   }
@@ -157,8 +157,6 @@ export default class SpotChecker {
   async spotCheck (task, maxByteLength) {
     const stats = newStats()
     await this.executeSpotCheck({ task, stats, maxByteLength })
-
-    console.log('Spot check completed: ', stats)
 
     Zinnia.jobCompleted()
     return stats

--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -142,11 +142,7 @@ export default class SpotChecker {
           resetTimeout()
         }
       } else {
-        console.error(
-          'Retrieval failed with status code %s: %s',
-          res.status,
-          (await res.text()).trimEnd()
-        )
+        console.error('Retrieval failed with status code %s: %s', res.status, (await res.text()).trimEnd())
       }
     } catch (err) {
       console.error(`Failed to fetch ${cid} from ${address} using ${protocol}`)

--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -39,7 +39,9 @@ export default class SpotChecker {
    * @param {number} [args.maxByteLength]
    * */
   async executeSpotCheck ({ task, stats, maxByteLength }) {
-    console.log(`Calling Filecoin JSON-RPC to get PeerId of miner ${task.minerId}`)
+    console.log(
+      `Calling Filecoin JSON-RPC to get PeerId of miner ${task.minerId}`
+    )
     try {
       const peerId = await this.#getMinerPeerId(task.minerId)
       console.log(`Found peer id: ${peerId}`)
@@ -54,7 +56,9 @@ export default class SpotChecker {
       // The third case should not happen unless we made a mistake, so we want to learn about it
       if (err.name === 'FilecoinRpcError') {
         // TODO: report the error to Sentry
-        console.error('The error printed below was not expected, please report it on GitHub:')
+        console.error(
+          'The error printed below was not expected, please report it on GitHub:'
+        )
         console.error('https://github.com/filecoin-station/spark/issues/new')
       }
       // Abort the check, no measurement should be recorded
@@ -62,10 +66,14 @@ export default class SpotChecker {
     }
 
     console.log(`Querying IPNI to find retrieval providers for ${task.cid}`)
-    const { indexerResult, provider } = await queryTheIndex(task.cid, stats.providerId)
+    const { indexerResult, provider } = await queryTheIndex(
+      task.cid,
+      stats.providerId
+    )
     stats.indexerResult = indexerResult
 
-    const providerFound = indexerResult === 'OK' || indexerResult === 'HTTP_NOT_ADVERTISED'
+    const providerFound =
+      indexerResult === 'OK' || indexerResult === 'HTTP_NOT_ADVERTISED'
     if (!providerFound) return
 
     stats.protocol = provider.protocol
@@ -76,8 +84,7 @@ export default class SpotChecker {
       address: provider.address,
       cid: task.cid,
       dagScope: 'block',
-      stats,
-      maxByteLength
+      stats: stats.blockRetrieval
     })
 
     await this.fetchCAR({
@@ -85,7 +92,7 @@ export default class SpotChecker {
       address: provider.address,
       cid: task.cid,
       dagScope: 'all',
-      stats,
+      stats: stats.fullRetrieval,
       maxByteLength
     })
   }
@@ -97,11 +104,9 @@ export default class SpotChecker {
    * @param {string} args.cid
    * @param {object} args.stats
    * @param {'all' | 'block'} args.dagScope
-   * @param {number} [args.maxByteLength=0] - Maximum bytes to download before stopping retrieval (applies to full retrievals only)
+   * @param {number} [args.maxByteLength]
    * */
-  async fetchCAR ({ protocol, address, cid, stats, dagScope, maxByteLength = 0 }) {
-    const retrievalStats = dagScope === 'all' ? stats.fullRetrieval : stats.blockRetrieval
-    maxByteLength = dagScope === 'all' ? maxByteLength : 0
+  async fetchCAR ({ protocol, address, cid, stats, dagScope, maxByteLength }) {
     // Abort if no progress was made for 60 seconds
     const controller = new AbortController()
     const { signal } = controller
@@ -111,7 +116,7 @@ export default class SpotChecker {
         clearTimeout(timeout)
       }
       timeout = setTimeout(() => {
-        retrievalStats.timeout = true
+        stats.timeout = true
         controller.abort()
       }, 60_000)
     }
@@ -122,31 +127,35 @@ export default class SpotChecker {
 
       resetTimeout()
       const res = await this.#fetch(url, { signal })
-      retrievalStats.statusCode = res.status
+      stats.statusCode = res.status
 
       if (res.ok) {
         resetTimeout()
         const reader = await CarBlockIterator.fromIterable(res.body)
         for await (const block of reader) {
-          retrievalStats.byteLength += block.bytes.length
+          stats.byteLength += block.bytes.length
           await validateBlock(block)
-          if (maxByteLength !=== undefined && retrievalStats.byteLength > maxByteLength) {
+          if (maxByteLength !== undefined && stats.byteLength > maxByteLength) {
             console.log('reached max, breaking')
             break
           }
           resetTimeout()
         }
       } else {
-        console.error('Retrieval failed with status code %s: %s',
-          res.status, (await res.text()).trimEnd())
+        console.error(
+          'Retrieval failed with status code %s: %s',
+          res.status,
+          (await res.text()).trimEnd()
+        )
       }
     } catch (err) {
       console.error(`Failed to fetch ${cid} from ${address} using ${protocol}`)
-      if (!retrievalStats.statusCode || retrievalStats.statusCode === 200) {
-        retrievalStats.statusCode = mapErrorToStatusCode(err)
+      if (!stats.statusCode || stats.statusCode === 200) {
+        stats.statusCode = mapErrorToStatusCode(err)
       }
     } finally {
       clearTimeout(timeout)
+      console.log(stats, dagScope)
     }
   }
 
@@ -175,7 +184,11 @@ export default class SpotChecker {
   async run ({ roundId, maxTasks, retrievalTasks, minerId, maxByteLength }) {
     const results = []
     if (!retrievalTasks.length) {
-      retrievalTasks = await this.#tasker.getRetrievalTasks({ roundId, maxTasks, minerId })
+      retrievalTasks = await this.#tasker.getRetrievalTasks({
+        roundId,
+        maxTasks,
+        minerId
+      })
     }
 
     if (!retrievalTasks.length) {

--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -39,9 +39,7 @@ export default class SpotChecker {
    * @param {number} [args.maxByteLength]
    * */
   async executeSpotCheck ({ task, stats, maxByteLength }) {
-    console.log(
-      `Calling Filecoin JSON-RPC to get PeerId of miner ${task.minerId}`
-    )
+    console.log(`Calling Filecoin JSON-RPC to get PeerId of miner ${task.minerId}`)
     try {
       const peerId = await this.#getMinerPeerId(task.minerId)
       console.log(`Found peer id: ${peerId}`)
@@ -56,9 +54,7 @@ export default class SpotChecker {
       // The third case should not happen unless we made a mistake, so we want to learn about it
       if (err.name === 'FilecoinRpcError') {
         // TODO: report the error to Sentry
-        console.error(
-          'The error printed below was not expected, please report it on GitHub:'
-        )
+        console.error('The error printed below was not expected, please report it on GitHub:')
         console.error('https://github.com/filecoin-station/spark/issues/new')
       }
       // Abort the check, no measurement should be recorded
@@ -66,14 +62,10 @@ export default class SpotChecker {
     }
 
     console.log(`Querying IPNI to find retrieval providers for ${task.cid}`)
-    const { indexerResult, provider } = await queryTheIndex(
-      task.cid,
-      stats.providerId
-    )
+    const { indexerResult, provider } = await queryTheIndex(task.cid, stats.providerId)
     stats.indexerResult = indexerResult
 
-    const providerFound =
-      indexerResult === 'OK' || indexerResult === 'HTTP_NOT_ADVERTISED'
+    const providerFound = indexerResult === 'OK' || indexerResult === 'HTTP_NOT_ADVERTISED'
     if (!providerFound) return
 
     stats.protocol = provider.protocol
@@ -142,7 +134,8 @@ export default class SpotChecker {
           resetTimeout()
         }
       } else {
-        console.error('Retrieval failed with status code %s: %s', res.status, (await res.text()).trimEnd())
+        console.error('Retrieval failed with status code %s: %s',
+          res.status, (await res.text()).trimEnd())
       }
     } catch (err) {
       console.error(`Failed to fetch ${cid} from ${address} using ${protocol}`)
@@ -179,11 +172,7 @@ export default class SpotChecker {
   async run ({ roundId, maxTasks, retrievalTasks, minerId, maxByteLength }) {
     const results = []
     if (!retrievalTasks.length) {
-      retrievalTasks = await this.#tasker.getRetrievalTasks({
-        roundId,
-        maxTasks,
-        minerId
-      })
+      retrievalTasks = await this.#tasker.getRetrievalTasks({ roundId, maxTasks, minerId })
     }
 
     if (!retrievalTasks.length) {

--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -130,7 +130,7 @@ export default class SpotChecker {
         for await (const block of reader) {
           retrievalStats.byteLength += block.bytes.length
           await validateBlock(block)
-          if (maxByteLength > 0 && retrievalStats.byteLength > maxByteLength) {
+          if (maxByteLength !=== undefined && retrievalStats.byteLength > maxByteLength) {
             console.log('reached max, breaking')
             break
           }

--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -151,7 +151,6 @@ export default class SpotChecker {
       }
     } finally {
       clearTimeout(timeout)
-      console.log(stats, dagScope)
     }
   }
 

--- a/lib/spot-checker.js
+++ b/lib/spot-checker.js
@@ -76,6 +76,16 @@ export default class SpotChecker {
       address: provider.address,
       cid: task.cid,
       stats,
+      dagScope: 'block',
+      maxByteLength
+    })
+
+    await this.fetchCAR({
+      protocol: provider.protocol,
+      address: provider.address,
+      cid: task.cid,
+      stats,
+      dagScope: 'all',
       maxByteLength
     })
   }
@@ -86,9 +96,12 @@ export default class SpotChecker {
    * @param {string} args.address
    * @param {string} args.cid
    * @param {object} args.stats
-   * @param {number} [args.maxByteLength]
+   * @param {'all' | 'block'} args.dagScope
+   * @param {number} [args.maxByteLength=0] - Maximum bytes to download before stopping retrieval (applies to full retrievals only)
    * */
-  async fetchCAR ({ protocol, address, cid, stats, maxByteLength }) {
+  async fetchCAR ({ protocol, address, cid, stats, dagScope, maxByteLength = 0 }) {
+    const retrievalStats = dagScope === 'all' ? stats.fullRetrieval : stats.blockRetrieval
+    maxByteLength = dagScope === 'all' ? maxByteLength : 0
     // Abort if no progress was made for 60 seconds
     const controller = new AbortController()
     const { signal } = controller
@@ -98,26 +111,26 @@ export default class SpotChecker {
         clearTimeout(timeout)
       }
       timeout = setTimeout(() => {
-        stats.timeout = true
+        retrievalStats.timeout = true
         controller.abort()
       }, 60_000)
     }
 
     try {
-      const url = getRetrievalUrl({ protocol, address, cid })
+      const url = getRetrievalUrl({ protocol, address, cid, dagScope })
       console.log(`Fetching: ${url}`)
 
       resetTimeout()
       const res = await this.#fetch(url, { signal })
-      stats.statusCode = res.status
+      retrievalStats.statusCode = res.status
 
       if (res.ok) {
         resetTimeout()
         const reader = await CarBlockIterator.fromIterable(res.body)
         for await (const block of reader) {
-          stats.byteLength += block.bytes.length
+          retrievalStats.byteLength += block.bytes.length
           await validateBlock(block)
-          if (maxByteLength > 0 && stats.byteLength > maxByteLength) {
+          if (maxByteLength > 0 && retrievalStats.byteLength > maxByteLength) {
             console.log('reached max, breaking')
             break
           }
@@ -129,8 +142,8 @@ export default class SpotChecker {
       }
     } catch (err) {
       console.error(`Failed to fetch ${cid} from ${address} using ${protocol}`)
-      if (!stats.statusCode || stats.statusCode === 200) {
-        stats.statusCode = mapErrorToStatusCode(err)
+      if (!retrievalStats.statusCode || retrievalStats.statusCode === 200) {
+        retrievalStats.statusCode = mapErrorToStatusCode(err)
       }
     } finally {
       clearTimeout(timeout)
@@ -144,6 +157,8 @@ export default class SpotChecker {
   async spotCheck (task, maxByteLength) {
     const stats = newStats()
     await this.executeSpotCheck({ task, stats, maxByteLength })
+
+    console.log('Spot check completed: ', stats)
 
     Zinnia.jobCompleted()
     return stats
@@ -186,9 +201,20 @@ export default class SpotChecker {
 
 export function newStats () {
   return {
-    timeout: false,
-    byteLength: 0,
-    statusCode: null
+    providerId: null,
+    indexerResult: null,
+    protocol: null,
+    providerAddress: null,
+    blockRetrieval: {
+      timeout: false,
+      byteLength: 0,
+      statusCode: null
+    },
+    fullRetrieval: {
+      timeout: false,
+      byteLength: 0,
+      statusCode: null
+    }
   }
 }
 
@@ -197,16 +223,17 @@ export function newStats () {
  * @param {RetrievalProtocol} args.protocol
  * @param {string} args.address
  * @param {string} args.cid
+ * @param {'all' | 'block'} dagScope
  * @returns {string}
  * @throws Will throw an error if invalid mutliaddr is supplied for http retrieval
  * */
-export function getRetrievalUrl ({ protocol, address, cid }) {
+export function getRetrievalUrl ({ protocol, address, cid, dagScope }) {
   if (protocol === 'http') {
     validateHttpMultiaddr(address)
   }
 
   const searchParams = new URLSearchParams({
-    'dag-scope': 'all',
+    'dag-scope': dagScope,
     protocols: protocol,
     providers: address
   })

--- a/lib/tasker.js
+++ b/lib/tasker.js
@@ -1,5 +1,3 @@
-/* global Zinnia */
-
 import { MERIDIAN_CONTRACT, SPARK_BASE_URL } from './constants.js'
 import { assertOkResponse } from './http-assertions.js'
 import { assertEquals, assertInstanceOf } from 'zinnia:assert'

--- a/test/integration.js
+++ b/test/integration.js
@@ -1,4 +1,4 @@
-import SpotChecker from '../lib/spot-checker.js'
+import SpotChecker, { newStats } from '../lib/spot-checker.js'
 import { test } from 'zinnia:test'
 import { assertEquals } from 'zinnia:assert'
 import { getMinerPeerId as defaultGetMinerPeerId } from '../lib/miner-info.js'
@@ -17,10 +17,12 @@ test('can execute spot check for our CID', async () => {
 
   // Run the check
   const spark = new SpotChecker({ getMinerPeerId })
-  const stats = { ...task, indexerResult: null, statusCode: null, byteLength: 0 }
+  const stats = { ...task, ...newStats() }
   await spark.executeSpotCheck({ task, stats })
 
-  assertEquals(stats.statusCode, 200, 'stats.statusCode')
   assertEquals(stats.indexerResult, 'OK', 'stats.indexerResult')
-  assertEquals(stats.byteLength, 103, 'stats.byteLength')
+  assertEquals(stats.fullRetrieval.statusCode, 200, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.byteLength, 103, 'stats.byteLength')
+  assertEquals(stats.blockRetrieval.statusCode, 200, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.byteLength, 103, 'stats.byteLength')
 })

--- a/test/spot-checker.js
+++ b/test/spot-checker.js
@@ -117,8 +117,8 @@ test('fetchCAR fails with statusCode=701 (unsupported host type)', async () => {
     stats: stats.blockRetrieval,
     dagScope: 'block'
   })
-  assertEquals(stats.fullRetrieval.statusCode, 701, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.statusCode, 701, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.statusCode, 701, 'stats.fullRetrieval.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 701, 'stats.blockRetrieval.statusCode')
 })
 
 test('fetchCAR fails with statusCode=702 (protocol is not tcp)', async () => {
@@ -138,8 +138,8 @@ test('fetchCAR fails with statusCode=702 (protocol is not tcp)', async () => {
     stats: stats.blockRetrieval,
     dagScope: 'block'
   })
-  assertEquals(stats.fullRetrieval.statusCode, 702, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.statusCode, 702, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.statusCode, 702, 'stats.fullRetrieval.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 702, 'stats.blockRetrieval.statusCode')
 })
 
 test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () => {
@@ -159,8 +159,8 @@ test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () =
     stats: stats.blockRetrieval,
     dagScope: 'block'
   })
-  assertEquals(stats.fullRetrieval.statusCode, 703, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.statusCode, 703, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.statusCode, 703, 'stats.fullRetrieval.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 703, 'stats.blockRetrieval.statusCode')
 })
 
 test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async () => {
@@ -180,8 +180,8 @@ test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async 
     stats: stats.blockRetrieval,
     dagScope: 'block'
   })
-  assertEquals(stats.fullRetrieval.statusCode, 704, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.statusCode, 704, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.statusCode, 704, 'stats.fullRetrieval.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 704, 'stats.blockRetrieval.statusCode')
 })
 
 test('fetchCAR fails with statusCode=502 (no candidates found)', async () => {
@@ -201,8 +201,8 @@ test('fetchCAR fails with statusCode=502 (no candidates found)', async () => {
     stats: stats.blockRetrieval,
     dagScope: 'block'
   })
-  assertEquals(stats.fullRetrieval.statusCode, 502, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.statusCode, 502, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.statusCode, 502, 'stats.fullRetrieval.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 502, 'stats.blockRetrieval.statusCode')
 })
 
 test('fetchCAR fails with statusCode=904 (cannot parse CAR)', async () => {
@@ -232,6 +232,6 @@ test('fetchCAR fails with statusCode=904 (cannot parse CAR)', async () => {
     stats: stats.blockRetrieval,
     dagScope: 'block'
   })
-  assertEquals(stats.fullRetrieval.statusCode, 904, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.statusCode, 904, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.statusCode, 904, 'stats.fullRetrieval.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 904, 'stats.blockRetrieval.statusCode')
 })

--- a/test/spot-checker.js
+++ b/test/spot-checker.js
@@ -17,12 +17,12 @@ test('fetchCAR - http', async () => {
     protocol: 'http',
     address: '/dns/frisbii.fly.dev/tcp/443/https',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all'
   })
 
   assertEquals(
-    stats.fullRetrieval, 
+    stats.fullRetrieval,
     { statusCode: 200, timeout: false, byteLength: 103 },
     'stats.fullRetrieval'
   )
@@ -31,13 +31,15 @@ test('fetchCAR - http', async () => {
     protocol: 'http',
     address: '/dns/frisbii.fly.dev/tcp/443/https',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
 
-  assertEquals(stats.blockRetrieval.statusCode, 200, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.timeout, false, 'stats.timeout')
-  assertEquals(stats.blockRetrieval.byteLength, 103, 'stats.byteLength')
+  assertEquals(
+    stats.blockRetrieval,
+    { statusCode: 200, timeout: false, byteLength: 103 },
+    'stats.blockRetrieval'
+  )
 
   assertEquals(requests, [
     `ipfs://${KNOWN_CID}?dag-scope=all&protocols=http&providers=%2Fdns%2Ffrisbii.fly.dev%2Ftcp%2F443%2Fhttps`,
@@ -52,7 +54,8 @@ test('fetchCAR - graphsync', async () => {
   // content that can be retrieved over Graphsync.
   // Hopefully, we will no longer support Graphsync by that time.
   const cid = 'bafybeiepi56qxfcwqgpstg25r6sonig7y3pzd37lwambzmlcmbnujjri4a'
-  const addr = '/dns/f010479.twinquasar.io/tcp/42002/p2p/12D3KooWHKeaNCnYByQUMS2n5PAZ1KZ9xKXqsb4bhpxVJ6bBJg5V'
+  const addr =
+    '/dns/f010479.twinquasar.io/tcp/42002/p2p/12D3KooWHKeaNCnYByQUMS2n5PAZ1KZ9xKXqsb4bhpxVJ6bBJg5V'
 
   const requests = []
   const spark = new SpotChecker({
@@ -66,26 +69,31 @@ test('fetchCAR - graphsync', async () => {
     protocol: 'graphsync',
     address: addr,
     cid,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
 
-  assertEquals(stats.blockRetrieval.statusCode, 200, 'stats.statusCode')
-  assertEquals(stats.blockRetrieval.timeout, false, 'stats.timeout')
-  assertEquals(stats.blockRetrieval.byteLength, 120, 'stats.byteLength')
+  assertEquals(
+    stats.blockRetrieval,
+    { statusCode: 200, timeout: false, byteLength: 120 },
+    'stats.blockRetrieval'
+  )
 
   await spark.fetchCAR({
     protocol: 'graphsync',
     address: addr,
     cid,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all',
     maxByteLength: 600 // download first two blocks
   })
 
-  assertEquals(stats.fullRetrieval.statusCode, 200, 'stats.statusCode')
-  assertEquals(stats.fullRetrieval.timeout, false, 'stats.timeout')
-  assertEquals(stats.fullRetrieval.byteLength, 601, 'stats.byteLength')
+  assertEquals(
+    stats.fullRetrieval,
+    { statusCode: 200, timeout: false, byteLength: 601 },
+    'stats.fullRetrieval'
+  )
+
   assertEquals(requests, [
     `ipfs://${cid}?dag-scope=block&protocols=graphsync&providers=${encodeURIComponent(addr)}`,
     `ipfs://${cid}?dag-scope=all&protocols=graphsync&providers=${encodeURIComponent(addr)}`
@@ -99,14 +107,14 @@ test('fetchCAR fails with statusCode=701 (unsupported host type)', async () => {
     protocol: 'http',
     address: '/ip99/1.2.3.4.5/tcp/80/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all'
   })
   await spark.fetchCAR({
     protocol: 'http',
     address: '/ip99/1.2.3.4.5/tcp/80/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
   assertEquals(stats.fullRetrieval.statusCode, 701, 'stats.statusCode')
@@ -120,14 +128,14 @@ test('fetchCAR fails with statusCode=702 (protocol is not tcp)', async () => {
     protocol: 'http',
     address: '/ip4/1.2.3.4/udp/80/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all'
   })
   await spark.fetchCAR({
     protocol: 'http',
     address: '/ip4/1.2.3.4/udp/80/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
   assertEquals(stats.fullRetrieval.statusCode, 702, 'stats.statusCode')
@@ -141,14 +149,14 @@ test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () =
     protocol: 'http',
     address: '/ip4/1.2.3.4/tcp/80/ldap',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all'
   })
   await spark.fetchCAR({
     protocol: 'http',
     address: '/ip4/1.2.3.4/tcp/80/ldap',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
   assertEquals(stats.fullRetrieval.statusCode, 703, 'stats.statusCode')
@@ -162,14 +170,14 @@ test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async 
     protocol: 'http',
     address: '/ip4/1.2.3.4/tcp/80/http/p2p/pubkey',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all'
   })
   await spark.fetchCAR({
     protocol: 'http',
     address: '/ip4/1.2.3.4/tcp/80/http/p2p/pubkey',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
   assertEquals(stats.fullRetrieval.statusCode, 704, 'stats.statusCode')
@@ -183,14 +191,14 @@ test('fetchCAR fails with statusCode=502 (no candidates found)', async () => {
     protocol: 'http',
     address: '/ip4/127.0.0.1/tcp/79/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all'
   })
   await spark.fetchCAR({
     protocol: 'http',
     address: '/ip4/127.0.0.1/tcp/79/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
   assertEquals(stats.fullRetrieval.statusCode, 502, 'stats.statusCode')
@@ -214,14 +222,14 @@ test('fetchCAR fails with statusCode=904 (cannot parse CAR)', async () => {
     protocol: 'http',
     address: '/ip4/127.0.0.1/tcp/80/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.fullRetrieval,
     dagScope: 'all'
   })
   await spark.fetchCAR({
     protocol: 'http',
     address: '/ip4/127.0.0.1/tcp/80/http',
     cid: KNOWN_CID,
-    stats,
+    stats: stats.blockRetrieval,
     dagScope: 'block'
   })
   assertEquals(stats.fullRetrieval.statusCode, 904, 'stats.statusCode')

--- a/test/spot-checker.js
+++ b/test/spot-checker.js
@@ -1,5 +1,3 @@
-/* global Zinnia */
-
 import SpotChecker, { newStats } from '../lib/spot-checker.js'
 import { test } from 'zinnia:test'
 import { assertEquals } from 'zinnia:assert'
@@ -19,12 +17,30 @@ test('fetchCAR - http', async () => {
     protocol: 'http',
     address: '/dns/frisbii.fly.dev/tcp/443/https',
     cid: KNOWN_CID,
-    stats
+    stats,
+    dagScope: 'all'
   })
-  assertEquals(stats.statusCode, 200, 'stats.statusCode')
-  assertEquals(stats.timeout, false, 'stats.timeout')
-  assertEquals(stats.byteLength, 103, 'stats.byteLength')
-  assertEquals(requests, [`ipfs://${KNOWN_CID}?dag-scope=all&protocols=http&providers=%2Fdns%2Ffrisbii.fly.dev%2Ftcp%2F443%2Fhttps`])
+
+  assertEquals(stats.fullRetrieval.statusCode, 200, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.timeout, false, 'stats.timeout')
+  assertEquals(stats.fullRetrieval.byteLength, 103, 'stats.byteLength')
+
+  await spark.fetchCAR({
+    protocol: 'http',
+    address: '/dns/frisbii.fly.dev/tcp/443/https',
+    cid: KNOWN_CID,
+    stats,
+    dagScope: 'block'
+  })
+
+  assertEquals(stats.blockRetrieval.statusCode, 200, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.timeout, false, 'stats.timeout')
+  assertEquals(stats.blockRetrieval.byteLength, 103, 'stats.byteLength')
+
+  assertEquals(requests, [
+    `ipfs://${KNOWN_CID}?dag-scope=all&protocols=http&providers=%2Fdns%2Ffrisbii.fly.dev%2Ftcp%2F443%2Fhttps`,
+    `ipfs://${KNOWN_CID}?dag-scope=block&protocols=http&providers=%2Fdns%2Ffrisbii.fly.dev%2Ftcp%2F443%2Fhttps`
+  ])
 })
 
 test('fetchCAR - graphsync', async () => {
@@ -49,12 +65,29 @@ test('fetchCAR - graphsync', async () => {
     address: addr,
     cid,
     stats,
+    dagScope: 'block'
+  })
+
+  assertEquals(stats.blockRetrieval.statusCode, 200, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.timeout, false, 'stats.timeout')
+  assertEquals(stats.blockRetrieval.byteLength, 120, 'stats.byteLength')
+
+  await spark.fetchCAR({
+    protocol: 'graphsync',
+    address: addr,
+    cid,
+    stats,
+    dagScope: 'all',
     maxByteLength: 600 // download first two blocks
   })
-  assertEquals(stats.statusCode, 200, 'stats.statusCode')
-  assertEquals(stats.timeout, false, 'stats.timeout')
-  assertEquals(stats.byteLength, 601, 'stats.byteLength')
-  assertEquals(requests, [`ipfs://${cid}?dag-scope=all&protocols=graphsync&providers=${encodeURIComponent(addr)}`])
+
+  assertEquals(stats.fullRetrieval.statusCode, 200, 'stats.statusCode')
+  assertEquals(stats.fullRetrieval.timeout, false, 'stats.timeout')
+  assertEquals(stats.fullRetrieval.byteLength, 601, 'stats.byteLength')
+  assertEquals(requests, [
+    `ipfs://${cid}?dag-scope=block&protocols=graphsync&providers=${encodeURIComponent(addr)}`,
+    `ipfs://${cid}?dag-scope=all&protocols=graphsync&providers=${encodeURIComponent(addr)}`
+  ])
 })
 
 test('fetchCAR fails with statusCode=701 (unsupported host type)', async () => {
@@ -64,9 +97,18 @@ test('fetchCAR fails with statusCode=701 (unsupported host type)', async () => {
     protocol: 'http',
     address: '/ip99/1.2.3.4.5/tcp/80/http',
     cid: KNOWN_CID,
-    stats
+    stats,
+    dagScope: 'all'
   })
-  assertEquals(stats.statusCode, 701, 'stats.statusCode')
+  await spark.fetchCAR({
+    protocol: 'http',
+    address: '/ip99/1.2.3.4.5/tcp/80/http',
+    cid: KNOWN_CID,
+    stats,
+    dagScope: 'block'
+  })
+  assertEquals(stats.fullRetrieval.statusCode, 701, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 701, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=702 (protocol is not tcp)', async () => {
@@ -76,10 +118,18 @@ test('fetchCAR fails with statusCode=702 (protocol is not tcp)', async () => {
     protocol: 'http',
     address: '/ip4/1.2.3.4/udp/80/http',
     cid: KNOWN_CID,
-    stats
-
+    stats,
+    dagScope: 'all'
   })
-  assertEquals(stats.statusCode, 702, 'stats.statusCode')
+  await spark.fetchCAR({
+    protocol: 'http',
+    address: '/ip4/1.2.3.4/udp/80/http',
+    cid: KNOWN_CID,
+    stats,
+    dagScope: 'block'
+  })
+  assertEquals(stats.fullRetrieval.statusCode, 702, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 702, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () => {
@@ -89,10 +139,18 @@ test('fetchCAR fails with statusCode=703 (scheme is not http/https)', async () =
     protocol: 'http',
     address: '/ip4/1.2.3.4/tcp/80/ldap',
     cid: KNOWN_CID,
-    stats
-
+    stats,
+    dagScope: 'all'
   })
-  assertEquals(stats.statusCode, 703, 'stats.statusCode')
+  await spark.fetchCAR({
+    protocol: 'http',
+    address: '/ip4/1.2.3.4/tcp/80/ldap',
+    cid: KNOWN_CID,
+    stats,
+    dagScope: 'block'
+  })
+  assertEquals(stats.fullRetrieval.statusCode, 703, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 703, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async () => {
@@ -102,10 +160,18 @@ test('fetchCAR fails with statusCode=704 (multiaddr has too many parts)', async 
     protocol: 'http',
     address: '/ip4/1.2.3.4/tcp/80/http/p2p/pubkey',
     cid: KNOWN_CID,
-    stats
-
+    stats,
+    dagScope: 'all'
   })
-  assertEquals(stats.statusCode, 704, 'stats.statusCode')
+  await spark.fetchCAR({
+    protocol: 'http',
+    address: '/ip4/1.2.3.4/tcp/80/http/p2p/pubkey',
+    cid: KNOWN_CID,
+    stats,
+    dagScope: 'block'
+  })
+  assertEquals(stats.fullRetrieval.statusCode, 704, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 704, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=502 (no candidates found)', async () => {
@@ -115,9 +181,18 @@ test('fetchCAR fails with statusCode=502 (no candidates found)', async () => {
     protocol: 'http',
     address: '/ip4/127.0.0.1/tcp/79/http',
     cid: KNOWN_CID,
-    stats
+    stats,
+    dagScope: 'all'
   })
-  assertEquals(stats.statusCode, 502, 'stats.statusCode')
+  await spark.fetchCAR({
+    protocol: 'http',
+    address: '/ip4/127.0.0.1/tcp/79/http',
+    cid: KNOWN_CID,
+    stats,
+    dagScope: 'block'
+  })
+  assertEquals(stats.fullRetrieval.statusCode, 502, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 502, 'stats.statusCode')
 })
 
 test('fetchCAR fails with statusCode=904 (cannot parse CAR)', async () => {
@@ -137,7 +212,16 @@ test('fetchCAR fails with statusCode=904 (cannot parse CAR)', async () => {
     protocol: 'http',
     address: '/ip4/127.0.0.1/tcp/80/http',
     cid: KNOWN_CID,
-    stats
+    stats,
+    dagScope: 'all'
   })
-  assertEquals(stats.statusCode, 904, 'stats.statusCode')
+  await spark.fetchCAR({
+    protocol: 'http',
+    address: '/ip4/127.0.0.1/tcp/80/http',
+    cid: KNOWN_CID,
+    stats,
+    dagScope: 'block'
+  })
+  assertEquals(stats.fullRetrieval.statusCode, 904, 'stats.statusCode')
+  assertEquals(stats.blockRetrieval.statusCode, 904, 'stats.statusCode')
 })

--- a/test/spot-checker.js
+++ b/test/spot-checker.js
@@ -21,9 +21,11 @@ test('fetchCAR - http', async () => {
     dagScope: 'all'
   })
 
-  assertEquals(stats.fullRetrieval.statusCode, 200, 'stats.statusCode')
-  assertEquals(stats.fullRetrieval.timeout, false, 'stats.timeout')
-  assertEquals(stats.fullRetrieval.byteLength, 103, 'stats.byteLength')
+  assertEquals(
+    stats.fullRetrieval, 
+    { statusCode: 200, timeout: false, byteLength: 103 },
+    'stats.fullRetrieval'
+  )
 
   await spark.fetchCAR({
     protocol: 'http',

--- a/test/tasker.test.js
+++ b/test/tasker.test.js
@@ -1,5 +1,3 @@
-/* global Zinnia */
-
 import { test } from 'zinnia:test'
 import { assertEquals } from 'zinnia:assert'
 import { pickTasks, Tasker } from '../lib/tasker.js'


### PR DESCRIPTION
This pull request introduces additional block retrievals to spot checks [suggested](https://github.com/CheckerNetwork/roadmap/issues/226#issuecomment-2704121752) by @bajtos . This retrieval is done before the full CAR retrieval.

`SpotChecker` changes:

* Added `dagScope` parameter to the `fetchCAR` method and updated its logic to handle different scopes (`'all'` or `'block'`).
* Updated the `newStats` function to include nested statistics for `blockRetrieval` and `fullRetrieval`, allowing for more granular tracking of retrieval operations.

Test changes:

* Modified test cases to account for the new `dagScope` parameter and updated assertions to verify the correct handling of `blockRetrieval` and `fullRetrieval` statistics.

Code cleanup:

* Removed global `Zinnia` references from several test files to streamline the codebase.


Related to: https://github.com/CheckerNetwork/roadmap/issues/226