### PR TITLE
chore: add workflow and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pyropy @juliangruber @NikolasHaimerl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,36 @@
+name: CI
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+env:
+  ZINNIA_VERSION: v0.20.2
+jobs:
+  test-linux:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run:
+          curl -L https://github.com/filecoin-station/zinnia/releases/download/${{ env.ZINNIA_VERSION }}/zinnia-linux-x64.tar.gz | tar -xz
+      - run: ./zinnia run test.js
+
+  test-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: robinraju/release-downloader@v1.11
+        with:
+          repository: 'filecoin-station/zinnia'
+          tag: ${{ env.ZINNIA_VERSION }}
+          fileName: zinnia-windows-x64.zip
+          extract: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - run: ./zinnia.exe run test.js
+
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+      - run: npx standard

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,19 +15,6 @@ jobs:
           curl -L https://github.com/filecoin-station/zinnia/releases/download/${{ env.ZINNIA_VERSION }}/zinnia-linux-x64.tar.gz | tar -xz
       - run: ./zinnia run test.js
 
-  test-windows:
-    runs-on: windows-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: robinraju/release-downloader@v1.11
-        with:
-          repository: 'filecoin-station/zinnia'
-          tag: ${{ env.ZINNIA_VERSION }}
-          fileName: zinnia-windows-x64.zip
-          extract: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-      - run: ./zinnia.exe run test.js
-
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -13,6 +13,19 @@ Once Zinnia is installed, you can execute Spark Spot Check with a simple command
 zinnia run main.js
 ```
 
+## Development
+
+Make sure you have installed [Zinnia runtime](https://github.com/CheckerNetwork/zinnia).
+
+```
+$ # Lint
+$ npx standard
+$ # Run module
+$ zinnia run main.js
+$ # Test module
+$ zinnia run test.js
+```
+
 ## Configuration
 All configuration options are managed through the `config.js` file. The following parameters can be customized:
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,4 +1,4 @@
 export const RPC_URL = 'https://api.node.glif.io/'
-export const RPC_AUTH = 'cL/ik5kups4LCAg6a+s6CS40/JcARERwZ4uMP8WI6ho='
+export const RPC_AUTH = 'KZLIUb9ejreYOm-mZFM3UNADE0ux6CrHjxnS2D2Qgb8='
 export const MERIDIAN_CONTRACT = '0x8460766edc62b525fc1fa4d628fc79229dc73031'
 export const SPARK_BASE_URL = 'https://api.filspark.com'


### PR DESCRIPTION
Adds missing github CI workflow, CODEOWNERS . Updates README file with the new development section and replaces old rpc token with the one found in [spark-checker](https://github.com/CheckerNetwork/spark-checker/blob/b98b08ce7865385ff9fe2d214a09c905465092a6/lib/constants.js#L6).